### PR TITLE
feat: add codex chat micro app

### DIFF
--- a/packages/codex-chat-app/README.md
+++ b/packages/codex-chat-app/README.md
@@ -1,0 +1,114 @@
+# Codex 模型对话微应用
+
+Codex 模型对话微应用提供了一个接近 [ChatGPT Codex](https://chatgpt.com/codex) 的界面体验，支持多会话管理、模型切换、工具控制与富文本渲染。该前端以 React + Vite 构建，可独立运行，也可作为主应用的微前端挂载。
+
+## 功能亮点
+
+- 🎛️ **模型与参数面板**：在顶部快速切换模型、调节温度，查看上下文窗口信息。
+- 🧰 **工具开关**：一键启用/禁用代码解释器、文件检索、联网搜索等能力，方便与后端工具链对接。
+- 💬 **对话体验**：支持 Markdown/GFM 渲染、代码高亮、工具调用结果展示、消息复制与重新生成。
+- 📁 **附件草稿**：允许在发送前添加多个附件（前端保存文件对象，发送时会附带元信息）。
+- 🗃️ **多会话管理**：侧边栏展示最近会话，可重命名、复制、删除或快速创建新会话，并自动根据更新时间排序。
+- 🧠 **本地持久化**：对话与配置存储在 `localStorage` 中，即便刷新页面也能恢复。
+
+## 开发与调试
+
+```bash
+pnpm install
+pnpm --filter codex-chat-app dev
+```
+
+Vite 开发服务器默认监听 `http://localhost:5180`，并自动设置跨域头，便于作为微应用在主应用中调试。
+
+## 与服务端的集成约定
+
+前端会调用 `POST /api/codex/chat` 接口获取模型回复（可通过 `VITE_CODEX_CHAT_API_BASE` 环境变量或 `window.__CODEX_CHAT_CONFIG__.apiBaseUrl` 覆盖基础地址）。请求体与响应体约定如下：
+
+### 请求体
+
+```jsonc
+{
+  "conversationId": "conv_xxx",
+  "settings": {
+    "model": "gpt-4.1-mini",
+    "temperature": 0.6,
+    "maxOutputTokens": null,
+  },
+  "tools": {
+    "codeInterpreter": true,
+    "fileSearch": false,
+    "webBrowsing": false,
+  },
+  "messages": [
+    { "id": "msg_1", "role": "user", "content": "帮我写个冒泡排序", "createdAt": "2025-01-01T00:00:00.000Z" },
+  ],
+  "attachments": [{ "id": "att_1", "name": "data.csv", "size": 10240, "type": "text/csv" }],
+  "stream": false,
+}
+```
+
+> 💡 **附件处理**：前端暂未上传文件内容，只会附带元信息。服务端需要提供单独的上传/引用机制，并在收到 `attachments` 后自行关联真实文件内容。
+
+### 响应体
+
+```jsonc
+{
+  "message": {
+    "content": "这是模型回复的正文，支持 Markdown。",
+    "toolCalls": [
+      {
+        "id": "tool_1",
+        "type": "code_interpreter",
+        "input": "print(1 + 1)",
+        "output": "2",
+        "createdAt": "2025-01-01T00:00:01.000Z",
+      },
+    ],
+    "status": "completed",
+  },
+  "usage": {
+    "promptTokens": 123,
+    "completionTokens": 456,
+    "totalTokens": 579,
+  },
+  "latencyMs": 1800,
+  "cached": false,
+}
+```
+
+- `status` 可选值：`pending`、`streaming`、`completed`、`error`。
+- `toolCalls` 用于回显诸如代码解释器或联网检索的执行结果。
+- 返回体若不符合 schema，前端会提示“服务端返回的结构不符合协议”。
+
+### 需要后端实现的扩展能力
+
+| 功能           | 说明                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------- |
+| 模型回复接口   | 实现 `POST /api/codex/chat`，可选支持 SSE 流式推送（前端预留 `stream` 字段用于扩展）。                  |
+| 附件上传与引用 | 提供文件上传接口，返回可在 `attachments` 中引用的 `id`，或在 `/api/codex/chat` 中同时接收元信息与内容。 |
+| 历史同步       | 若需云端同步会话，可在服务端落库并返回持久化 ID，前端通过配置中心注入用户态信息。                       |
+| 安全校验       | 建议对请求附带的模型 ID、工具开关进行校验，并限制高风险指令。                                           |
+
+## 构建与部署
+
+```bash
+pnpm --filter codex-chat-app build
+```
+
+构建产物位于 `packages/codex-chat-app/dist`，生产环境需通过主应用或独立服务器将其部署到 `/codex-chat-app/` 路径。
+
+## 目录结构
+
+```
+packages/codex-chat-app
+├── src
+│   ├── components      # 侧边栏、消息列表、输入框等 UI 组件
+│   ├── constants       # 模型定义等常量
+│   ├── hooks           # 对话状态管理（含本地存储）
+│   ├── services        # 与服务端交互、数据校验
+│   ├── utils           # ID 生成与本地持久化工具
+│   └── App.tsx         # 路由与页面骨架
+└── vite.config.ts
+```
+
+欢迎在此基础上接入真实模型与工具链，构建属于你的 Codex 工作台。

--- a/packages/codex-chat-app/index.html
+++ b/packages/codex-chat-app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex 模型对话</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/codex-chat-app/package.json
+++ b/packages/codex-chat-app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "codex-chat-app",
+  "version": "0.0.1",
+  "private": true,
+  "description": "面向大模型对话体验的微应用，提供类似 ChatGPT Codex 的交互界面",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ice/stark-app": "^1.5.0",
+    "clsx": "^2.1.1",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.9.3",
+    "vite": "^7.1.10",
+    "vite-plugin-index-html": "^2.0.2"
+  }
+}

--- a/packages/codex-chat-app/src/App.tsx
+++ b/packages/codex-chat-app/src/App.tsx
@@ -1,0 +1,9 @@
+import ChatWorkspace from './components/ChatWorkspace';
+
+type AppProps = {
+  basename?: string;
+};
+
+export default function App(_props: AppProps) {
+  return <ChatWorkspace />;
+}

--- a/packages/codex-chat-app/src/components/ChatHeader.tsx
+++ b/packages/codex-chat-app/src/components/ChatHeader.tsx
@@ -1,0 +1,164 @@
+import clsx from 'clsx';
+import { useMemo } from 'react';
+
+import { MODEL_GROUPS } from '../constants/models';
+import type { Conversation, ToolConfig } from '../types';
+
+const IconSparkles = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+    <path
+      d="M9 1.5 7.5 6 3 7.5 7.5 9 9 13.5 10.5 9 15 7.5 10.5 6 9 1.5Z"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconStop = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+    <rect x="4.2" y="4.2" width="7.6" height="7.6" rx="1.2" fill="currentColor" />
+  </svg>
+);
+
+type ChatHeaderProps = {
+  activeConversation: Conversation | null;
+  isGenerating: boolean;
+  onNewConversation: () => void;
+  onDuplicateConversation: () => void;
+  onClearConversation: () => void;
+  onCancelGeneration: () => void;
+  onToggleSidebar: () => void;
+  onModelChange: (modelId: string) => void;
+  onTemperatureChange: (value: number) => void;
+  onToggleTool: (tool: keyof ToolConfig, value: boolean) => void;
+};
+
+export default function ChatHeader({
+  activeConversation,
+  isGenerating,
+  onNewConversation,
+  onDuplicateConversation,
+  onClearConversation,
+  onCancelGeneration,
+  onToggleSidebar,
+  onModelChange,
+  onTemperatureChange,
+  onToggleTool,
+}: ChatHeaderProps) {
+  const currentModel = activeConversation?.settings.model ?? MODEL_GROUPS[0]?.models[0]?.id;
+
+  const modelDescription = useMemo(() => {
+    for (const group of MODEL_GROUPS) {
+      const found = group.models.find((model) => model.id === currentModel);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  }, [currentModel]);
+
+  return (
+    <header className="chat-header">
+      <div className="chat-header-top">
+        <div className="brand">
+          <span className="brand-logo">CX</span>
+          <div>
+            <div className="title" style={{ fontWeight: 600, fontSize: 18 }}>
+              Codex 对话空间
+            </div>
+            <div className="tagline">
+              {modelDescription
+                ? `${modelDescription.label} · ${modelDescription.description}`
+                : '选择一个模型开始创作，或上传上下文以增强回答效果。'}
+            </div>
+          </div>
+        </div>
+        <div className="chat-header-actions">
+          <button type="button" className="secondary-button" onClick={onToggleSidebar}>
+            菜单
+          </button>
+          <button type="button" className="secondary-button" onClick={onDuplicateConversation}>
+            复制会话
+          </button>
+          <button type="button" className="secondary-button" onClick={onClearConversation}>
+            清空会话
+          </button>
+          <button type="button" className="primary-button" onClick={onNewConversation}>
+            <IconSparkles /> 发起新对话
+          </button>
+          {isGenerating && (
+            <button type="button" className="secondary-button" onClick={onCancelGeneration}>
+              <IconStop /> 停止生成
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="model-settings-panel">
+        <div className="setting-block">
+          <h4>模型</h4>
+          <div className="model-select">
+            <select value={currentModel} onChange={(event) => onModelChange(event.target.value)} aria-label="选择模型">
+              {MODEL_GROUPS.map((group) => (
+                <optgroup key={group.group} label={group.group}>
+                  {group.models.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.label}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+            {modelDescription?.contextWindow && (
+              <span className="hint-text">上下文：{modelDescription.contextWindow}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="setting-block">
+          <h4>温度</h4>
+          <p>控制创造力与确定性，值越大输出越发散。</p>
+          <div className="temperature-slider">
+            <input
+              type="range"
+              min="0"
+              max="2"
+              step="0.1"
+              value={activeConversation?.settings.temperature ?? 0.6}
+              onChange={(event) => onTemperatureChange(Number(event.target.value))}
+              aria-label="设置温度"
+            />
+            <span>{(activeConversation?.settings.temperature ?? 0.6).toFixed(1)}</span>
+          </div>
+        </div>
+
+        <div className="setting-block">
+          <h4>工具</h4>
+          <p>结合多种能力构建智能体工作流。</p>
+          <div className="tool-toggle-group">
+            {(
+              [
+                { key: 'codeInterpreter', label: '代码解释器', description: '执行 Python / JS 代码' },
+                { key: 'fileSearch', label: '文件检索', description: '索引上传的知识库' },
+                { key: 'webBrowsing', label: '联网搜索', description: '实时获取最新资料' },
+              ] as Array<{ key: keyof ToolConfig; label: string; description: string }>
+            ).map((tool) => (
+              <button
+                key={tool.key}
+                type="button"
+                className={clsx('tool-toggle', activeConversation?.tools?.[tool.key] && 'active')}
+                onClick={() => onToggleTool(tool.key, !activeConversation?.tools?.[tool.key])}
+                title={tool.description}
+              >
+                {tool.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/packages/codex-chat-app/src/components/ChatWorkspace.tsx
+++ b/packages/codex-chat-app/src/components/ChatWorkspace.tsx
@@ -1,0 +1,191 @@
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+
+import Composer from './Composer';
+import Sidebar from './Sidebar';
+import ChatHeader from './ChatHeader';
+import MessageList from './MessageList';
+import { useChatState } from '../hooks/useChatState';
+import type { ComposerAttachment } from '../types';
+import { createId } from '../utils/storage';
+
+const MAX_ATTACHMENTS = 5;
+const MAX_ATTACHMENT_SIZE_MB = 20;
+
+export default function ChatWorkspace() {
+  const {
+    conversations,
+    activeConversation,
+    activeConversationId,
+    isGenerating,
+    createConversation,
+    selectConversation,
+    renameConversation,
+    deleteConversation,
+    duplicateConversation,
+    updateSettings,
+    toggleTool,
+    sendMessage,
+    cancelGeneration,
+    clearConversation,
+  } = useChatState();
+
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+
+  const messages = useMemo(() => activeConversation?.messages ?? [], [activeConversation?.messages]);
+
+  const handleCreateConversation = () => {
+    createConversation();
+    setDraft('');
+    setAttachments([]);
+    setSidebarMobileOpen(false);
+  };
+
+  const handleSelectConversation = (conversationId: string) => {
+    selectConversation(conversationId);
+    setSidebarMobileOpen(false);
+  };
+
+  const handleDeleteConversation = (conversationId: string) => {
+    if (window.confirm('确定要删除该会话吗？')) {
+      deleteConversation(conversationId);
+    }
+  };
+
+  const handleUpload = (fileList: FileList | null) => {
+    if (!fileList || fileList.length === 0) {
+      return;
+    }
+    const remainingSlots = MAX_ATTACHMENTS - attachments.length;
+    if (remainingSlots <= 0) {
+      setAttachmentError(`最多可附加 ${MAX_ATTACHMENTS} 个文件。`);
+      return;
+    }
+    const selectedFiles = Array.from(fileList).slice(0, remainingSlots);
+    const oversize = selectedFiles.find((file) => file.size > MAX_ATTACHMENT_SIZE_MB * 1024 * 1024);
+    if (oversize) {
+      setAttachmentError(`单个文件大小需小于 ${MAX_ATTACHMENT_SIZE_MB} MB。`);
+      return;
+    }
+    const nextAttachments = selectedFiles.map((file) => ({ id: createId('att'), file }));
+    setAttachments((prev) => [...prev, ...nextAttachments]);
+    setAttachmentError(null);
+  };
+
+  const handleRemoveAttachment = (attachmentId: string) => {
+    setAttachments((prev) => prev.filter((item) => item.id !== attachmentId));
+  };
+
+  const handleSend = async () => {
+    if (!draft.trim()) {
+      return;
+    }
+    const attachmentMetadata = attachments.map((item) => ({
+      id: item.id,
+      name: item.file.name,
+      size: item.file.size,
+      type: item.file.type,
+    }));
+    await sendMessage(draft, { attachments: attachmentMetadata });
+    setDraft('');
+    setAttachments([]);
+  };
+
+  const handleRegenerate = () => {
+    const lastUserMessage = [...messages].reverse().find((message) => message.role === 'user');
+    if (!lastUserMessage) {
+      return;
+    }
+    sendMessage(lastUserMessage.content, { attachments: lastUserMessage.attachments });
+  };
+
+  const handleModelChange = (modelId: string) => {
+    if (!activeConversationId) {
+      return;
+    }
+    updateSettings(activeConversationId, { model: modelId });
+  };
+
+  const handleTemperatureChange = (value: number) => {
+    if (!activeConversationId) {
+      return;
+    }
+    updateSettings(activeConversationId, { temperature: value });
+  };
+
+  const handleToggleTool = (tool: Parameters<typeof toggleTool>[1], value: boolean) => {
+    if (!activeConversationId) {
+      return;
+    }
+    toggleTool(activeConversationId, tool, value);
+  };
+
+  const handleDuplicate = () => {
+    if (!activeConversationId) {
+      return;
+    }
+    duplicateConversation(activeConversationId);
+  };
+
+  const handleClearConversation = () => {
+    if (!activeConversationId) {
+      return;
+    }
+    if (window.confirm('确定要清空当前会话的历史记录吗？')) {
+      clearConversation(activeConversationId);
+      setDraft('');
+      setAttachments([]);
+    }
+  };
+
+  const layoutClass = clsx('workspace', sidebarCollapsed && 'sidebar-collapsed');
+
+  return (
+    <div className={layoutClass}>
+      {sidebarMobileOpen && <div className="sidebar-overlay" onClick={() => setSidebarMobileOpen(false)} />}
+      <Sidebar
+        conversations={conversations}
+        activeConversationId={activeConversationId}
+        collapsed={sidebarCollapsed}
+        mobileOpen={sidebarMobileOpen}
+        onToggleCollapse={() => setSidebarCollapsed((prev) => !prev)}
+        onMobileClose={() => setSidebarMobileOpen(false)}
+        onSelectConversation={handleSelectConversation}
+        onCreateConversation={handleCreateConversation}
+        onRenameConversation={renameConversation}
+        onDeleteConversation={handleDeleteConversation}
+        onDuplicateConversation={duplicateConversation}
+      />
+      <main className="chat-area">
+        <ChatHeader
+          activeConversation={activeConversation ?? null}
+          isGenerating={isGenerating}
+          onNewConversation={handleCreateConversation}
+          onDuplicateConversation={handleDuplicate}
+          onClearConversation={handleClearConversation}
+          onCancelGeneration={cancelGeneration}
+          onToggleSidebar={() => setSidebarMobileOpen((prev) => !prev)}
+          onModelChange={handleModelChange}
+          onTemperatureChange={handleTemperatureChange}
+          onToggleTool={handleToggleTool}
+        />
+        <MessageList messages={messages} isGenerating={isGenerating} onRegenerate={handleRegenerate} />
+        <Composer
+          value={draft}
+          attachments={attachments}
+          isGenerating={isGenerating}
+          disabled={isGenerating}
+          errorMessage={attachmentError}
+          onChange={setDraft}
+          onSubmit={handleSend}
+          onUpload={handleUpload}
+          onRemoveAttachment={handleRemoveAttachment}
+        />
+      </main>
+    </div>
+  );
+}

--- a/packages/codex-chat-app/src/components/Composer.tsx
+++ b/packages/codex-chat-app/src/components/Composer.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, type KeyboardEvent } from 'react';
+import clsx from 'clsx';
+
+import type { ComposerAttachment } from '../types';
+
+const IconUpload = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+    <path
+      d="M3 10.5v1.4c0 .56 0 .84.11 1.054a1 1 0 0 0 .436.436c.214.11.494.11 1.054.11h6.8c.56 0 .84 0 1.054-.11a1 1 0 0 0 .436-.436c.11-.214.11-.494.11-1.054v-1.4"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      fill="none"
+      strokeLinecap="round"
+    />
+    <path
+      d="M8 9.5V2.2m0 0L5.5 4.7m2.5-2.5L10.5 4.7"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconLightning = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+    <path
+      d="M6.1 1.2 2.7 7.1c-.226.396-.34.595-.29.743.043.128.172.214.454.214H6l-.6 4.4 5.9-6.9c.226-.264.34-.396.29-.544-.043-.128-.172-.214-.454-.214H8l.6-4.4-2.5 2.943Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+type ComposerProps = {
+  value: string;
+  attachments: ComposerAttachment[];
+  disabled?: boolean;
+  isGenerating: boolean;
+  errorMessage?: string | null;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  onUpload: (files: FileList | null) => void;
+  onRemoveAttachment: (attachmentId: string) => void;
+};
+
+export default function Composer({
+  value,
+  attachments,
+  disabled,
+  isGenerating,
+  errorMessage,
+  onChange,
+  onSubmit,
+  onUpload,
+  onRemoveAttachment,
+}: ComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+    textarea.style.height = 'auto';
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 220)}px`;
+  }, [value]);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      if (!disabled && value.trim()) {
+        onSubmit();
+      }
+    }
+  };
+
+  return (
+    <div className="composer-shell">
+      <div className="composer" role="form" aria-label="提示词输入区">
+        {errorMessage && <div className="alert warning">{errorMessage}</div>}
+        {attachments.length > 0 && (
+          <div className="attachment-preview">
+            {attachments.map((attachment) => (
+              <span key={attachment.id} className="attachment-pill">
+                {attachment.file.name}
+                <span className="hint-text">{(attachment.file.size / 1024).toFixed(1)} KB</span>
+                <button type="button" onClick={() => onRemoveAttachment(attachment.id)} aria-label="移除附件">
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={isGenerating ? '正在等待模型响应…' : '提出需求、添加上下文或描述你想要的结果'}
+          aria-label="输入提示词"
+          disabled={disabled}
+        />
+
+        <div className="composer-toolbar">
+          <div className="composer-left">
+            <input
+              ref={fileInputRef}
+              type="file"
+              hidden
+              multiple
+              onChange={(event) => {
+                onUpload(event.target.files);
+                if (event.target) {
+                  event.target.value = '';
+                }
+              }}
+            />
+            <button
+              type="button"
+              className="icon-button"
+              onClick={() => fileInputRef.current?.click()}
+              title="上传文件"
+              aria-label="上传文件"
+              disabled={disabled}
+            >
+              <IconUpload />
+            </button>
+            <span className="hint-text">支持代码解释器与文件检索</span>
+          </div>
+          <div className="composer-right">
+            <span className="hint-text">Shift + Enter 换行</span>
+            <button
+              type="button"
+              className={clsx('send-button')}
+              onClick={onSubmit}
+              disabled={disabled || !value.trim()}
+            >
+              <IconLightning /> 发送
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/codex-chat-app/src/components/Markdown.tsx
+++ b/packages/codex-chat-app/src/components/Markdown.tsx
@@ -1,0 +1,16 @@
+import { memo, useMemo } from 'react';
+
+import { renderMarkdownToHtml } from '../utils/markdown';
+
+type MarkdownProps = {
+  content: string;
+};
+
+const Markdown = memo(({ content }: MarkdownProps) => {
+  const html = useMemo(() => renderMarkdownToHtml(content), [content]);
+  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+});
+
+Markdown.displayName = 'Markdown';
+
+export default Markdown;

--- a/packages/codex-chat-app/src/components/MessageList.tsx
+++ b/packages/codex-chat-app/src/components/MessageList.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useMemo, useRef } from 'react';
+import clsx from 'clsx';
+
+import type { ChatMessage } from '../types';
+import Markdown from './Markdown';
+
+const IconCopy = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+    <path
+      d="M4.2 4.2V2.8c0-.994 0-1.49.193-1.863a1.5 1.5 0 0 1 .644-.644C5.41.1 5.906.1 6.9.1h2.1c.994 0 1.49 0 1.863.193a1.5 1.5 0 0 1 .644.644C11.7 1.31 11.7 1.806 11.7 2.8v2.1c0 .994 0 1.49-.193 1.863a1.5 1.5 0 0 1-.644.644C10.39 7.6 9.894 7.6 8.9 7.6H6.8c-.994 0-1.49 0-1.863-.193a1.5 1.5 0 0 1-.644-.644C4.2 5.69 4.2 5.194 4.2 4.2Z"
+      stroke="currentColor"
+      strokeWidth="1.1"
+      fill="none"
+    />
+    <path
+      d="M2.8 13.9h2.1c.994 0 1.49 0 1.863-.193a1.5 1.5 0 0 0 .644-.644c.193-.373.193-.869.193-1.863V9.1c0-.994 0-1.49-.193-1.863a1.5 1.5 0 0 0-.644-.644C6.39 6.4 5.894 6.4 4.9 6.4H2.8c-.994 0-1.49 0-1.863.193a1.5 1.5 0 0 0-.644.644C0.1 7.61 0.1 8.106 0.1 9.1v2.1c0 .994 0 1.49.193 1.863.145.279.365.499.644.644.373.193.869.193 1.863.193Z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.1"
+    />
+  </svg>
+);
+
+const IconRefresh = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+    <path d="M12.3 6.5A4.8 4.8 0 1 1 7 2.7" stroke="currentColor" strokeWidth="1.2" fill="none" strokeLinecap="round" />
+    <path
+      d="M8.5 1.2 11 2.1 10.1 4.6"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+type MessageListProps = {
+  messages: ChatMessage[];
+  isGenerating: boolean;
+  onRegenerate: () => void;
+};
+
+const timeFormatter = new Intl.DateTimeFormat('zh-CN', {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+});
+
+const formatTime = (iso: string) => {
+  try {
+    return timeFormatter.format(new Date(iso));
+  } catch {
+    return '';
+  }
+};
+
+const isAssistant = (message: ChatMessage) => message.role === 'assistant';
+
+export default function MessageList({ messages, isGenerating, onRegenerate }: MessageListProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) {
+      return;
+    }
+    element.scrollTo({ top: element.scrollHeight, behavior: 'smooth' });
+  }, [messages.length]);
+
+  const hasConversation = useMemo(() => messages.length > 0, [messages.length]);
+
+  if (!hasConversation) {
+    return (
+      <div className="message-area">
+        <div className="message-scroll" ref={scrollRef}>
+          <div className="empty-state">
+            <strong>准备好开始创作了吗？</strong>
+            <span>输入提示词、上传附件或选择模板，即可体验类似 ChatGPT Codex 的高级对话功能。</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const lastAssistantMessage = [...messages].reverse().find(isAssistant);
+
+  const copyToClipboard = async (content: string) => {
+    try {
+      await navigator.clipboard.writeText(content);
+    } catch {
+      // ignore clipboard failure silently
+    }
+  };
+
+  return (
+    <div className="message-area">
+      <div className="message-scroll" ref={scrollRef}>
+        <div className="message-timeline">
+          {messages.map((message) => {
+            const isUser = message.role === 'user';
+            const statusClass = message.status === 'error' ? 'message-status error' : 'message-status';
+            return (
+              <article key={message.id} className="message-card">
+                <div className={clsx('message-avatar', isUser && 'user')}>{isUser ? '你' : 'AI'}</div>
+                <div className={clsx('message-body', isUser && 'user')}>
+                  <div className="message-header">
+                    <span>
+                      {isUser ? '用户' : 'Codex'} · {formatTime(message.createdAt)}
+                    </span>
+                    {message.status && (
+                      <span className={statusClass}>
+                        {message.status === 'pending' && '生成中…'}
+                        {message.status === 'streaming' && '流式生成'}
+                        {message.status === 'completed' && '已完成'}
+                        {message.status === 'error' && '出现问题'}
+                      </span>
+                    )}
+                  </div>
+                  <div className="message-content">
+                    <Markdown content={message.content} />
+                  </div>
+
+                  {message.attachments && message.attachments.length > 0 && (
+                    <div className="attachment-preview">
+                      {message.attachments.map((attachment) => (
+                        <span key={attachment.id} className="attachment-pill">
+                          {attachment.name}
+                          <span className="hint-text">{(attachment.size / 1024).toFixed(1)} KB</span>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {message.toolCalls && message.toolCalls.length > 0 && (
+                    <div className="tool-call">
+                      {message.toolCalls.map((tool) => (
+                        <div key={tool.id}>
+                          <div className="tool-name">{tool.type === 'code_interpreter' ? '代码解释器' : tool.type}</div>
+                          <div className="hint-text">输入</div>
+                          <pre>{tool.input}</pre>
+                          {tool.output && (
+                            <>
+                              <div className="hint-text">输出</div>
+                              <pre>{tool.output}</pre>
+                            </>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  <div className="message-actions">
+                    <button
+                      type="button"
+                      className="message-action-button"
+                      onClick={() => copyToClipboard(message.content)}
+                    >
+                      <IconCopy /> 复制
+                    </button>
+                    {lastAssistantMessage?.id === message.id && !isGenerating && (
+                      <button type="button" className="message-action-button" onClick={onRegenerate}>
+                        <IconRefresh /> 重新生成
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/codex-chat-app/src/components/Sidebar.tsx
+++ b/packages/codex-chat-app/src/components/Sidebar.tsx
@@ -1,0 +1,260 @@
+import { useMemo, useState, type KeyboardEvent } from 'react';
+import clsx from 'clsx';
+
+import type { Conversation } from '../types';
+
+const dateFormatter = new Intl.DateTimeFormat('zh-CN', {
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+const formatDate = (input: string) => {
+  try {
+    return dateFormatter.format(new Date(input));
+  } catch {
+    return '';
+  }
+};
+
+type SidebarProps = {
+  conversations: Conversation[];
+  activeConversationId: string | null;
+  collapsed: boolean;
+  mobileOpen: boolean;
+  onToggleCollapse: () => void;
+  onMobileClose: () => void;
+  onSelectConversation: (conversationId: string) => void;
+  onCreateConversation: () => void;
+  onRenameConversation: (conversationId: string, title: string) => void;
+  onDeleteConversation: (conversationId: string) => void;
+  onDuplicateConversation: (conversationId: string) => void;
+};
+
+const IconPlus = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+    <path d="M7 1.5v11m-5.5-5.5h11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const IconMenu = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+    <path d="M3 5h12m-12 4h9m-9 4h12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const IconEdit = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+    <path
+      d="M8.828 2.172 2.5 8.5 2 11.5l3-.5 6.328-6.328a1.5 1.5 0 0 0 0-2.121l-.879-.879a1.5 1.5 0 0 0-2.121 0Z"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconDuplicate = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+    <path
+      d="M5 4.2V2.8c0-.994 0-1.49.193-1.863a1.5 1.5 0 0 1 .644-.644C6.21.1 6.706.1 7.7.1h2.1c.994 0 1.49 0 1.863.193a1.5 1.5 0 0 1 .644.644C12.5 1.31 12.5 1.806 12.5 2.8v2.1c0 .994 0 1.49-.193 1.863a1.5 1.5 0 0 1-.644.644c-.373.193-.869.193-1.863.193H7.7c-.994 0-1.49 0-1.863-.193a1.5 1.5 0 0 1-.644-.644C5 5.69 5 5.194 5 4.2Z"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      fill="none"
+    />
+    <path
+      d="M2.8 13.9h2.1c.994 0 1.49 0 1.863-.193a1.5 1.5 0 0 0 .644-.644c.193-.373.193-.869.193-1.863V9.1c0-.994 0-1.49-.193-1.863a1.5 1.5 0 0 0-.644-.644C7.39 6.4 6.894 6.4 5.9 6.4H3.8c-.994 0-1.49 0-1.863.193a1.5 1.5 0 0 0-.644.644C1.1 7.61 1.1 8.106 1.1 9.1v2.1c0 .994 0 1.49.193 1.863.145.279.365.499.644.644.373.193.869.193 1.863.193Z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+    />
+  </svg>
+);
+
+const IconTrash = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+    <path d="M3.5 4.5h7" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    <path
+      d="M5 4.5v5.5m2-5.5v5.5m2-8-.341-1.023A1 1 0 0 0 7.711.5H6.289a1 1 0 0 0-.948.977L5 2.5m6 0-.387 8.132c-.047.991-.07 1.486-.284 1.834a1.5 1.5 0 0 1-.63.561c-.34.173-.834.173-1.822.173H5.123c-.988 0-1.482 0-1.822-.173a1.5 1.5 0 0 1-.63-.561c-.214-.348-.237-.843-.284-1.834L2 2.5"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconChevron = ({ collapsed }: { collapsed: boolean }) => (
+  <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+    <path
+      d={collapsed ? 'm7 4 4 5-4 5' : 'm11 4-4 5 4 5'}
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const BrandMark = () => (
+  <div className="brand">
+    <span className="brand-logo">CX</span>
+    <span className="brand-label">Codex</span>
+  </div>
+);
+
+export default function Sidebar({
+  conversations,
+  activeConversationId,
+  collapsed,
+  mobileOpen,
+  onToggleCollapse,
+  onMobileClose,
+  onSelectConversation,
+  onCreateConversation,
+  onRenameConversation,
+  onDeleteConversation,
+  onDuplicateConversation,
+}: SidebarProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draftTitle, setDraftTitle] = useState('');
+
+  const sortedConversations = useMemo(
+    () => [...conversations].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1)),
+    [conversations],
+  );
+
+  const startEditing = (conversationId: string, title: string) => {
+    setEditingId(conversationId);
+    setDraftTitle(title);
+  };
+
+  const commitEditing = () => {
+    if (!editingId) {
+      return;
+    }
+    onRenameConversation(editingId, draftTitle);
+    setEditingId(null);
+    setDraftTitle('');
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitEditing();
+    }
+  };
+
+  return (
+    <aside className={clsx('sidebar', collapsed && 'collapsed', mobileOpen && 'is-open')} aria-label="会话导航">
+      <div className="sidebar-header">
+        <BrandMark />
+        <div className="sidebar-actions">
+          <button
+            type="button"
+            className="sidebar-action-button"
+            onClick={onToggleCollapse}
+            aria-label={collapsed ? '展开侧边栏' : '折叠侧边栏'}
+          >
+            <IconChevron collapsed={collapsed} />
+          </button>
+          <button type="button" className="sidebar-action-button" onClick={onMobileClose} aria-label="关闭侧边栏">
+            <IconMenu />
+          </button>
+        </div>
+      </div>
+
+      <button type="button" className="new-conversation-button" onClick={onCreateConversation}>
+        <span className="icon">
+          <IconPlus />
+        </span>
+        <span className="label">发起新对话</span>
+      </button>
+
+      <div className="sidebar-content">
+        <section className="sidebar-section">
+          <div className="sidebar-section-header">
+            <span>最近会话</span>
+            <span className="badge">实时同步</span>
+          </div>
+          <div className="conversation-list">
+            {sortedConversations.map((conversation) => {
+              const isActive = conversation.id === activeConversationId;
+              return (
+                <button
+                  key={conversation.id}
+                  type="button"
+                  className={clsx('conversation-item', isActive && 'active')}
+                  onClick={() => onSelectConversation(conversation.id)}
+                >
+                  <div className="title">
+                    {editingId === conversation.id ? (
+                      <input
+                        value={draftTitle}
+                        onChange={(event) => setDraftTitle(event.target.value)}
+                        onBlur={commitEditing}
+                        onKeyDown={handleKeyDown}
+                        autoFocus
+                      />
+                    ) : (
+                      <span>{conversation.title}</span>
+                    )}
+                    <div className="sidebar-actions">
+                      <button
+                        type="button"
+                        className="sidebar-action-button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onDuplicateConversation(conversation.id);
+                        }}
+                        aria-label="复制会话"
+                      >
+                        <IconDuplicate />
+                      </button>
+                      <button
+                        type="button"
+                        className="sidebar-action-button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          startEditing(conversation.id, conversation.title);
+                        }}
+                        aria-label="重命名"
+                      >
+                        <IconEdit />
+                      </button>
+                      <button
+                        type="button"
+                        className="sidebar-action-button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onDeleteConversation(conversation.id);
+                        }}
+                        aria-label="删除会话"
+                      >
+                        <IconTrash />
+                      </button>
+                    </div>
+                  </div>
+                  <div className="meta">
+                    <span>{formatDate(conversation.updatedAt)}</span>
+                    <span>{conversation.settings.model}</span>
+                  </div>
+                </button>
+              );
+            })}
+            {sortedConversations.length === 0 && (
+              <div className="empty-state">
+                <strong>暂无会话</strong>
+                <span>点击上方按钮创建第一个对话。</span>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/packages/codex-chat-app/src/constants/models.ts
+++ b/packages/codex-chat-app/src/constants/models.ts
@@ -1,0 +1,87 @@
+export type ModelDefinition = {
+  id: string;
+  label: string;
+  description: string;
+  capability: 'general' | 'reasoning' | 'coding' | 'voice';
+  contextWindow?: string;
+  latencyHint?: string;
+  releaseTag?: string;
+};
+
+export const MODEL_GROUPS: Array<{
+  group: string;
+  models: ModelDefinition[];
+}> = [
+  {
+    group: '旗舰模型',
+    models: [
+      {
+        id: 'gpt-4.1',
+        label: 'GPT-4.1',
+        description: '适合通用对话、知识问答与轻量推理任务',
+        capability: 'general',
+        contextWindow: '200K',
+        latencyHint: '低延迟',
+      },
+      {
+        id: 'gpt-4.1-mini',
+        label: 'GPT-4.1 Mini',
+        description: '成本优化版本，适合批量自动化与助手类应用',
+        capability: 'general',
+        contextWindow: '128K',
+        latencyHint: '极低延迟',
+      },
+      {
+        id: 'o4-mini',
+        label: 'o4 Mini (Reasoning)',
+        description: '覆盖逻辑推理与工具调用的平衡型号',
+        capability: 'reasoning',
+        contextWindow: '200K',
+        releaseTag: 'Beta',
+      },
+      {
+        id: 'o1',
+        label: 'o1 (深度推理)',
+        description: '对复杂规划、数学证明等任务具备更强的推理能力',
+        capability: 'reasoning',
+        contextWindow: '128K',
+        latencyHint: '较高延迟',
+      },
+    ],
+  },
+  {
+    group: '代码与智能体',
+    models: [
+      {
+        id: 'gpt-4.1-coder',
+        label: 'GPT-4.1 Coder',
+        description: '专注于代码生成、调试及代码解释器协作场景',
+        capability: 'coding',
+        contextWindow: '200K',
+        releaseTag: 'Preview',
+      },
+      {
+        id: 'o3-mini-high',
+        label: 'o3 Mini High',
+        description: '适合编写复杂脚本、构建自动化代理',
+        capability: 'coding',
+        contextWindow: '128K',
+      },
+    ],
+  },
+  {
+    group: '语音与多模态',
+    models: [
+      {
+        id: 'gpt-4o-audio-preview',
+        label: 'GPT-4o Audio Preview',
+        description: '低延迟语音互动、实时多模态体验',
+        capability: 'voice',
+        contextWindow: '64K',
+        releaseTag: 'Preview',
+      },
+    ],
+  },
+];
+
+export const DEFAULT_MODEL_ID = 'gpt-4.1-mini';

--- a/packages/codex-chat-app/src/env.d.ts
+++ b/packages/codex-chat-app/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/codex-chat-app/src/hooks/useChatState.ts
+++ b/packages/codex-chat-app/src/hooks/useChatState.ts
@@ -1,0 +1,399 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type {
+  Attachment,
+  ChatMessage,
+  ChatStateSnapshot,
+  Conversation,
+  ConversationSettings,
+  ToolConfig,
+} from '../types';
+import { DEFAULT_MODEL_ID } from '../constants/models';
+import { createChatCompletion, ChatServiceError } from '../services/chatService';
+import { createId, loadSnapshot, persistSnapshot } from '../utils/storage';
+
+const DEFAULT_TITLE = '新对话';
+
+const createWelcomeConversation = (): Conversation => {
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const introMessage: ChatMessage = {
+    id: createId('msg'),
+    role: 'assistant',
+    createdAt: nowIso,
+    status: 'completed',
+    content: `欢迎体验 **Codex 模型对话** ✨\n\n这个微应用旨在复刻 ChatGPT Codex 的常用工作流，支持多轮上下文、模型切换、工具组合以及对话管理。\n\n**你可以尝试：**\n- 上传文件并结合代码解释器完成数据分析\n- 切换到 \`o1\` 或 \`o4 Mini\` 体验更深入的推理能力\n- 通过提示模板快速搭建个人助理\n- 配合即将上线的服务端 API 获取真实模型响应\n\n下面演示了一个代码解释器的输出：\n\n\`\`\`python\nfor i in range(1, 4):\n    print(f"Codex demo #{i}")\n\`\`\``,
+    toolCalls: [
+      {
+        id: createId('tool'),
+        type: 'code_interpreter',
+        input: 'for i in range(1, 4):\n    print("Codex demo #", i)',
+        output: ['Codex demo #1', 'Codex demo #2', 'Codex demo #3'].join('\n'),
+        createdAt: nowIso,
+      },
+    ],
+  };
+
+  return {
+    id: createId('conv'),
+    title: '欢迎体验 Codex',
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    messages: [introMessage],
+    settings: {
+      model: DEFAULT_MODEL_ID,
+      temperature: 0.6,
+      maxOutputTokens: null,
+    },
+    tools: {
+      codeInterpreter: true,
+      fileSearch: false,
+      webBrowsing: false,
+    },
+  };
+};
+
+const createInitialSnapshot = (): ChatStateSnapshot => {
+  const fallbackConversation = createWelcomeConversation();
+  return {
+    conversations: [fallbackConversation],
+    activeConversationId: fallbackConversation.id,
+  };
+};
+
+const deriveTitleFromMessage = (content: string) => {
+  const condensed = content.replace(/\s+/g, ' ').trim();
+  if (!condensed) {
+    return DEFAULT_TITLE;
+  }
+  const slice = condensed.slice(0, 36);
+  return condensed.length > 36 ? `${slice}…` : slice;
+};
+
+const normalizeTitle = (conversation: Conversation, draftTitle: string, latestUserMessage: string) => {
+  if (draftTitle && draftTitle !== DEFAULT_TITLE) {
+    return draftTitle;
+  }
+  const hasUserHistory = conversation.messages.some((msg) => msg.role === 'user');
+  if (hasUserHistory) {
+    return conversation.title;
+  }
+  return deriveTitleFromMessage(latestUserMessage);
+};
+
+const updateConversationState = (
+  conversations: Conversation[],
+  conversationId: string,
+  updater: (conversation: Conversation) => Conversation,
+) => conversations.map((conversation) => (conversation.id === conversationId ? updater(conversation) : conversation));
+
+type SendOptions = {
+  attachments?: Attachment[];
+};
+
+type UseChatStateResult = {
+  conversations: Conversation[];
+  activeConversationId: string | null;
+  activeConversation: Conversation | null;
+  isGenerating: boolean;
+  createConversation: (options?: Partial<Conversation>) => Conversation;
+  selectConversation: (conversationId: string) => void;
+  renameConversation: (conversationId: string, title: string) => void;
+  deleteConversation: (conversationId: string) => void;
+  duplicateConversation: (conversationId: string) => void;
+  updateSettings: (conversationId: string, settings: Partial<ConversationSettings>) => void;
+  toggleTool: (conversationId: string, key: keyof ToolConfig, value: boolean) => void;
+  sendMessage: (content: string, options?: SendOptions) => Promise<void>;
+  cancelGeneration: () => void;
+  clearConversation: (conversationId: string) => void;
+  clearAll: () => void;
+};
+
+export const useChatState = (): UseChatStateResult => {
+  const [initialSnapshot] = useState<ChatStateSnapshot>(() => loadSnapshot() ?? createInitialSnapshot());
+
+  const [conversations, setConversations] = useState<Conversation[]>(initialSnapshot.conversations);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(
+    initialSnapshot.activeConversationId ?? initialSnapshot.conversations[0]?.id ?? null,
+  );
+  const [isGenerating, setIsGenerating] = useState(false);
+  const pendingAssistantRef = useRef<{ conversationId: string; messageId: string } | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const activeConversation = useMemo(
+    () => conversations.find((conversation) => conversation.id === activeConversationId) ?? null,
+    [conversations, activeConversationId],
+  );
+
+  useEffect(() => {
+    persistSnapshot({ conversations, activeConversationId });
+  }, [conversations, activeConversationId]);
+
+  const selectConversation = useCallback((conversationId: string) => {
+    setActiveConversationId(conversationId);
+  }, []);
+
+  const createConversation = useCallback((options: Partial<Conversation> = {}) => {
+    const now = new Date().toISOString();
+    const conversation: Conversation = {
+      id: options.id ?? createId('conv'),
+      title: options.title ?? DEFAULT_TITLE,
+      createdAt: options.createdAt ?? now,
+      updatedAt: options.updatedAt ?? now,
+      messages: options.messages ?? [],
+      settings: {
+        model: options.settings?.model ?? DEFAULT_MODEL_ID,
+        temperature: options.settings?.temperature ?? 0.6,
+        maxOutputTokens: options.settings?.maxOutputTokens ?? null,
+      },
+      tools: {
+        codeInterpreter: options.tools?.codeInterpreter ?? true,
+        fileSearch: options.tools?.fileSearch ?? false,
+        webBrowsing: options.tools?.webBrowsing ?? false,
+      },
+    };
+
+    setConversations((prev) => [conversation, ...prev]);
+    setActiveConversationId(conversation.id);
+    return conversation;
+  }, []);
+
+  const renameConversation = useCallback((conversationId: string, title: string) => {
+    setConversations((prev) =>
+      updateConversationState(prev, conversationId, (conversation) => ({
+        ...conversation,
+        title: title.trim() ? title.trim() : DEFAULT_TITLE,
+      })),
+    );
+  }, []);
+
+  const deleteConversation = useCallback((conversationId: string) => {
+    setConversations((prev) => {
+      const next = prev.filter((conversation) => conversation.id !== conversationId);
+      setActiveConversationId((current) => {
+        if (current && current !== conversationId) {
+          return current;
+        }
+        return next[0]?.id ?? null;
+      });
+      return next;
+    });
+  }, []);
+
+  const duplicateConversation = useCallback(
+    (conversationId: string) => {
+      const source = conversations.find((conversation) => conversation.id === conversationId);
+      if (!source) {
+        return;
+      }
+      const now = new Date().toISOString();
+      const clone: Conversation = {
+        ...source,
+        id: createId('conv'),
+        title: `${source.title}（副本）`,
+        createdAt: now,
+        updatedAt: now,
+        messages: source.messages.map((message) => ({
+          ...message,
+          id: createId('msg'),
+        })),
+      };
+      setConversations((prev) => [clone, ...prev]);
+      setActiveConversationId(clone.id);
+    },
+    [conversations],
+  );
+
+  const updateSettings = useCallback((conversationId: string, settings: Partial<ConversationSettings>) => {
+    setConversations((prev) =>
+      updateConversationState(prev, conversationId, (conversation) => ({
+        ...conversation,
+        settings: { ...conversation.settings, ...settings },
+      })),
+    );
+  }, []);
+
+  const toggleTool = useCallback((conversationId: string, key: keyof ToolConfig, value: boolean) => {
+    setConversations((prev) =>
+      updateConversationState(prev, conversationId, (conversation) => ({
+        ...conversation,
+        tools: { ...conversation.tools, [key]: value },
+      })),
+    );
+  }, []);
+
+  const clearConversation = useCallback((conversationId: string) => {
+    const timestamp = new Date().toISOString();
+    setConversations((prev) =>
+      updateConversationState(prev, conversationId, (conversation) => ({
+        ...conversation,
+        title: DEFAULT_TITLE,
+        updatedAt: timestamp,
+        messages: [],
+      })),
+    );
+  }, []);
+
+  const clearAll = useCallback(() => {
+    const fresh = createInitialSnapshot();
+    setConversations(fresh.conversations);
+    setActiveConversationId(fresh.activeConversationId);
+    persistSnapshot(fresh);
+  }, []);
+
+  const cancelGeneration = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+    const pending = pendingAssistantRef.current;
+    if (!pending) {
+      return;
+    }
+    setConversations((prev) =>
+      updateConversationState(prev, pending.conversationId, (conversation) => ({
+        ...conversation,
+        messages: conversation.messages.map((message) =>
+          message.id === pending.messageId
+            ? {
+                ...message,
+                status: 'error',
+                content: '已取消生成。',
+              }
+            : message,
+        ),
+      })),
+    );
+    pendingAssistantRef.current = null;
+    setIsGenerating(false);
+  }, []);
+
+  const sendMessage = useCallback(
+    async (content: string, options: SendOptions = {}) => {
+      const trimmed = content.trim();
+      if (!trimmed) {
+        return;
+      }
+      if (isGenerating) {
+        return;
+      }
+
+      let conversation = activeConversation;
+      if (!conversation) {
+        conversation = createConversation();
+      }
+      if (!conversation) {
+        return;
+      }
+
+      const conversationId = conversation.id;
+      const timestamp = new Date();
+      const userMessage: ChatMessage = {
+        id: createId('msg'),
+        role: 'user',
+        content: trimmed,
+        createdAt: timestamp.toISOString(),
+        attachments: options.attachments,
+      };
+      const assistantMessage: ChatMessage = {
+        id: createId('msg'),
+        role: 'assistant',
+        content: '',
+        createdAt: new Date(timestamp.getTime() + 1).toISOString(),
+        status: 'pending',
+      };
+
+      setConversations((prev) =>
+        updateConversationState(prev, conversationId, (target) => ({
+          ...target,
+          title: normalizeTitle(target, target.title, trimmed),
+          updatedAt: assistantMessage.createdAt,
+          messages: [...target.messages, userMessage, assistantMessage],
+        })),
+      );
+
+      const payloadMessages = [...conversation.messages, userMessage];
+      const payloadAttachments = options.attachments ?? [];
+
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      pendingAssistantRef.current = { conversationId, messageId: assistantMessage.id };
+      setIsGenerating(true);
+
+      try {
+        const response = await createChatCompletion(
+          {
+            conversationId,
+            messages: payloadMessages,
+            settings: conversation.settings,
+            tools: conversation.tools,
+            attachments: payloadAttachments,
+            stream: false,
+          },
+          { signal: controller.signal },
+        );
+
+        setConversations((prev) =>
+          updateConversationState(prev, conversationId, (target) => ({
+            ...target,
+            updatedAt: new Date().toISOString(),
+            messages: target.messages.map((message) =>
+              message.id === assistantMessage.id
+                ? {
+                    ...message,
+                    content: response.message.content,
+                    toolCalls: response.message.toolCalls,
+                    status: response.message.status ?? 'completed',
+                  }
+                : message,
+            ),
+          })),
+        );
+      } catch (error) {
+        if ((error as DOMException)?.name === 'AbortError') {
+          // 已在 cancelGeneration 中处理
+          return;
+        }
+        const friendlyMessage =
+          error instanceof ChatServiceError ? error.friendlyMessage : '暂时无法获取模型响应，请稍后再试。';
+        setConversations((prev) =>
+          updateConversationState(prev, conversationId, (target) => ({
+            ...target,
+            messages: target.messages.map((message) =>
+              message.id === assistantMessage.id
+                ? {
+                    ...message,
+                    status: 'error',
+                    content: friendlyMessage,
+                  }
+                : message,
+            ),
+          })),
+        );
+      } finally {
+        pendingAssistantRef.current = null;
+        abortControllerRef.current = null;
+        setIsGenerating(false);
+      }
+    },
+    [activeConversation, createConversation, isGenerating],
+  );
+
+  return {
+    conversations,
+    activeConversationId,
+    activeConversation,
+    isGenerating,
+    createConversation,
+    selectConversation,
+    renameConversation,
+    deleteConversation,
+    duplicateConversation,
+    updateSettings,
+    toggleTool,
+    sendMessage,
+    cancelGeneration,
+    clearConversation,
+    clearAll,
+  };
+};

--- a/packages/codex-chat-app/src/main.tsx
+++ b/packages/codex-chat-app/src/main.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import isInIcestark from '@ice/stark-app/lib/isInIcestark';
+import getBasename from '@ice/stark-app/lib/getBasename';
+import setLibraryName from '@ice/stark-app/lib/setLibraryName';
+
+import App from './App';
+import './styles.css';
+
+setLibraryName('codex-chat-app');
+
+type MountOptions = {
+  container?: Element | string;
+  basename?: string;
+  customProps?: {
+    container?: Element | string;
+    basename?: string;
+  };
+};
+
+type RenderOptions = {
+  container: Element;
+  basename?: string;
+};
+
+let appRoot: ReactDOM.Root | null = null;
+
+const resolveContainer = (target?: Element | string | null): Element | null => {
+  if (!target) {
+    return null;
+  }
+  return typeof target === 'string' ? document.querySelector(target) : target;
+};
+
+const renderApp = ({ container, basename }: RenderOptions) => {
+  if (appRoot) {
+    appRoot.unmount();
+  }
+
+  appRoot = ReactDOM.createRoot(container);
+  appRoot.render(
+    <React.StrictMode>
+      <App basename={basename ?? getBasename()} />
+    </React.StrictMode>,
+  );
+};
+
+export const unmount = async () => {
+  if (appRoot) {
+    appRoot.unmount();
+    appRoot = null;
+  }
+};
+
+export const mount = async (options: MountOptions = {}) => {
+  const { container, basename, customProps } = options;
+  const fallbackSelector = isInIcestark() ? undefined : '#root';
+  const containerSource = container ?? customProps?.container ?? fallbackSelector;
+  const target = resolveContainer(containerSource);
+
+  if (!target) {
+    console.warn('[codex-chat-app] mount skipped: container missing');
+    return;
+  }
+
+  renderApp({
+    container: target,
+    basename: basename ?? customProps?.basename,
+  });
+};
+
+if (!isInIcestark()) {
+  mount({ container: '#root', basename: import.meta.env.BASE_URL });
+}

--- a/packages/codex-chat-app/src/services/chatService.ts
+++ b/packages/codex-chat-app/src/services/chatService.ts
@@ -1,0 +1,171 @@
+import type { ChatRequest, ChatResponse, ToolCall } from '../types';
+
+const TOOL_STATUS_SET = new Set(['pending', 'streaming', 'completed', 'error']);
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+const normalizeToolCall = (value: unknown): ToolCall | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const { id, type, input, output, createdAt } = value;
+  if (
+    typeof id !== 'string' ||
+    typeof type !== 'string' ||
+    typeof input !== 'string' ||
+    typeof createdAt !== 'string'
+  ) {
+    return null;
+  }
+  if (!['code_interpreter', 'file_search', 'web_browsing', 'custom'].includes(type)) {
+    return null;
+  }
+  return {
+    id,
+    type: type as ToolCall['type'],
+    input,
+    output: typeof output === 'string' ? output : undefined,
+    createdAt,
+  };
+};
+
+const normalizeResponse = (data: unknown): ChatResponse => {
+  if (!isRecord(data) || !isRecord(data.message) || typeof data.message.content !== 'string') {
+    throw new ChatServiceError('INVALID_RESPONSE', '响应结构与预期不符。', {
+      friendlyMessage: '服务端返回的结构不符合协议，请参阅微应用内的开发文档完成实现。',
+    });
+  }
+
+  const messageRecord = data.message as Record<string, unknown> & { content: string };
+  const normalized: ChatResponse = {
+    message: {
+      content: messageRecord.content,
+    },
+  };
+
+  if (Array.isArray(messageRecord.toolCalls)) {
+    normalized.message.toolCalls = messageRecord.toolCalls
+      .map(normalizeToolCall)
+      .filter((item): item is ToolCall => Boolean(item));
+  }
+
+  if (typeof messageRecord.status === 'string' && TOOL_STATUS_SET.has(messageRecord.status)) {
+    normalized.message.status = messageRecord.status as ChatResponse['message']['status'];
+  }
+
+  if (isRecord(data.usage)) {
+    const usageRecord = data.usage;
+    normalized.usage = {
+      promptTokens: typeof usageRecord.promptTokens === 'number' ? usageRecord.promptTokens : undefined,
+      completionTokens: typeof usageRecord.completionTokens === 'number' ? usageRecord.completionTokens : undefined,
+      totalTokens: typeof usageRecord.totalTokens === 'number' ? usageRecord.totalTokens : undefined,
+    };
+  }
+
+  if (typeof data.latencyMs === 'number') {
+    normalized.latencyMs = data.latencyMs;
+  }
+
+  if (typeof data.cached === 'boolean') {
+    normalized.cached = data.cached;
+  }
+
+  return normalized;
+};
+
+export class ChatServiceError extends Error {
+  readonly code: 'HTTP_ERROR' | 'NETWORK_ERROR' | 'INVALID_RESPONSE' | 'SERVICE_UNAVAILABLE' | 'UNEXPECTED';
+  readonly status?: number;
+  readonly friendlyMessage: string;
+
+  constructor(
+    code: ChatServiceError['code'],
+    message: string,
+    options: { status?: number; friendlyMessage?: string; cause?: unknown } = {},
+  ) {
+    super(message);
+    this.name = 'ChatServiceError';
+    this.code = code;
+    this.status = options.status;
+    this.friendlyMessage = options.friendlyMessage ?? message;
+    if (Object.prototype.hasOwnProperty.call(options, 'cause')) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+type RequestOptions = {
+  signal?: AbortSignal;
+};
+
+const resolveApiBase = () => {
+  if (typeof window !== 'undefined') {
+    const runtimeConfig = (
+      window as typeof window & {
+        __CODEX_CHAT_CONFIG__?: { apiBaseUrl?: string };
+      }
+    ).__CODEX_CHAT_CONFIG__;
+    if (runtimeConfig?.apiBaseUrl) {
+      return runtimeConfig.apiBaseUrl.replace(/\/$/, '');
+    }
+  }
+  if (import.meta.env.VITE_CODEX_CHAT_API_BASE) {
+    return String(import.meta.env.VITE_CODEX_CHAT_API_BASE).replace(/\/$/, '');
+  }
+  return '';
+};
+
+const buildEndpoint = () => {
+  const base = resolveApiBase();
+  if (!base) {
+    return '/api/codex/chat';
+  }
+  return `${base}/chat`;
+};
+
+export async function createChatCompletion(payload: ChatRequest, options: RequestOptions = {}): Promise<ChatResponse> {
+  const endpoint = buildEndpoint();
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal: options.signal,
+    });
+  } catch (error) {
+    throw new ChatServiceError('NETWORK_ERROR', '无法连接到对话服务。', {
+      friendlyMessage: '暂时无法连接到对话服务，请确认服务端是否已部署并允许运行。',
+      cause: error,
+    });
+  }
+
+  if (response.status === 404 || response.status === 501) {
+    throw new ChatServiceError('SERVICE_UNAVAILABLE', '服务端未实现对话接口。', {
+      status: response.status,
+      friendlyMessage: '未检测到可用的对话服务端，请按照 README 中的说明实现 /api/codex/chat 接口后重试。',
+    });
+  }
+
+  if (!response.ok) {
+    throw new ChatServiceError('HTTP_ERROR', `请求失败：${response.status}`, {
+      status: response.status,
+      friendlyMessage: '服务端返回了错误状态码，请稍后再试或检查日志。',
+    });
+  }
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw new ChatServiceError('INVALID_RESPONSE', '响应解析失败。', {
+      friendlyMessage: '无法解析模型响应，请检查服务端返回的数据格式。',
+      cause: error,
+    });
+  }
+
+  return normalizeResponse(data);
+}

--- a/packages/codex-chat-app/src/styles.css
+++ b/packages/codex-chat-app/src/styles.css
@@ -1,0 +1,910 @@
+:root {
+  color-scheme: dark;
+  --bg-page: #030712;
+  --bg-surface: #0b1220;
+  --bg-surface-hover: #111a2d;
+  --bg-input: rgba(15, 23, 42, 0.9);
+  --bg-toolbar: rgba(15, 23, 42, 0.65);
+  --bg-tooltip: #1f2937;
+  --border-color: rgba(148, 163, 184, 0.15);
+  --border-strong: rgba(148, 163, 184, 0.3);
+  --text-primary: #f8fafc;
+  --text-secondary: rgba(226, 232, 240, 0.7);
+  --text-tertiary: rgba(203, 213, 225, 0.45);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --danger: #f87171;
+  --success: #4ade80;
+  --warning: #fbbf24;
+  --shadow-strong: 0 20px 45px rgba(15, 23, 42, 0.45);
+  --radius-lg: 18px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  --transition: 160ms ease;
+  --sidebar-width: 300px;
+  --sidebar-width-collapsed: 90px;
+  font-family: 'Inter', 'SF Pro Display', 'SF Pro Text', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.12), transparent 40%), var(--bg-page);
+  color: var(--text-primary);
+  overflow: hidden;
+}
+
+body {
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
+}
+
+button {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+textarea {
+  resize: none;
+}
+
+::selection {
+  background: rgba(56, 189, 248, 0.35);
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(71, 85, 105, 0.45);
+  border-radius: 9999px;
+}
+
+.workspace {
+  height: 100%;
+  display: grid;
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  transition: grid-template-columns var(--transition);
+  backdrop-filter: blur(20px);
+}
+
+.workspace.sidebar-collapsed {
+  grid-template-columns: var(--sidebar-width-collapsed) minmax(0, 1fr);
+}
+
+.sidebar {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px 18px;
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.85) 0%, rgba(15, 23, 42, 0.78) 100%);
+  border-right: 1px solid var(--border-color);
+  overflow: hidden;
+  transition:
+    width var(--transition),
+    padding var(--transition);
+}
+
+.sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.18), transparent 60%);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  z-index: 1;
+}
+
+.brand {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.brand-logo {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.8), rgba(8, 47, 73, 0.9));
+  box-shadow: 0 12px 30px rgba(14, 165, 233, 0.22);
+  font-weight: 700;
+  font-size: 18px;
+}
+
+.sidebar-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.sidebar-action-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+  transition:
+    background var(--transition),
+    transform var(--transition),
+    color var(--transition);
+}
+
+.sidebar-action-button:hover {
+  background: rgba(14, 165, 233, 0.18);
+  color: var(--text-primary);
+  transform: translateY(-2px);
+}
+
+.new-conversation-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  padding: 12px 14px;
+  font-size: 14px;
+  background: linear-gradient(120deg, rgba(148, 163, 184, 0.12), rgba(15, 23, 42, 0.6));
+  color: var(--text-secondary);
+  transition: all var(--transition);
+}
+
+.new-conversation-button span.icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  background: rgba(56, 189, 248, 0.16);
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+}
+
+.new-conversation-button:hover {
+  color: var(--text-primary);
+  border-color: rgba(56, 189, 248, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.18);
+  transform: translateY(-1px);
+}
+
+.sidebar-content {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-height: 0;
+}
+
+.sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.sidebar-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+
+.conversation-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.conversation-item {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  color: var(--text-secondary);
+  transition: all var(--transition);
+}
+
+.conversation-item:hover,
+.conversation-item.active {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.26), rgba(15, 23, 42, 0.7));
+  border-color: rgba(56, 189, 248, 0.55);
+  color: var(--text-primary);
+  box-shadow: 0 10px 24px rgba(14, 165, 233, 0.2);
+}
+
+.conversation-item .title {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.conversation-item .title input {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-weight: inherit;
+  outline: none;
+}
+
+.conversation-item .meta {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  display: flex;
+  justify-content: space-between;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 2px 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+
+.chat-area {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: rgba(2, 6, 23, 0.45);
+  border-left: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.chat-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 22px 28px 18px;
+  background: rgba(2, 6, 23, 0.75);
+  backdrop-filter: blur(24px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.chat-header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.chat-header-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.primary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  padding: 9px 14px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.24), rgba(14, 165, 233, 0.14));
+  color: var(--text-primary);
+  font-size: 14px;
+  transition:
+    transform var(--transition),
+    box-shadow var(--transition);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(56, 189, 248, 0.25);
+}
+
+.secondary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  padding: 8px 14px;
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text-secondary);
+  font-size: 13px;
+  transition:
+    transform var(--transition),
+    border-color var(--transition);
+}
+
+.secondary-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(148, 163, 184, 0.4);
+  color: var(--text-primary);
+}
+
+.tagline {
+  color: var(--text-tertiary);
+  font-size: 13px;
+  max-width: 780px;
+}
+
+.model-settings-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(15, 23, 42, 0.48);
+}
+
+.setting-block {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.setting-block h4 {
+  margin: 0;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+}
+
+.setting-block p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.model-select {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.model-select select {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.9);
+  padding: 10px 12px;
+  color: var(--text-primary);
+  transition:
+    border-color var(--transition),
+    box-shadow var(--transition);
+}
+
+.model-select select:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.3);
+}
+
+.temperature-slider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.temperature-slider input[type='range'] {
+  flex: 1;
+  accent-color: var(--accent);
+}
+
+.tool-toggle-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.tool-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  padding: 6px 12px;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.tool-toggle.active {
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--text-primary);
+  border-color: rgba(56, 189, 248, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.28);
+}
+
+.message-area {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.message-scroll {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  padding: 20px 0 140px;
+}
+
+.message-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: 0 28px;
+}
+
+.message-card {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 18px;
+}
+
+.message-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.45), rgba(14, 165, 233, 0.16));
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.message-avatar.user {
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+}
+
+.message-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: var(--shadow-strong);
+}
+
+.message-body.user {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.2), rgba(15, 23, 42, 0.7));
+}
+
+.message-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+  color: var(--text-tertiary);
+}
+
+.message-content {
+  color: var(--text-primary);
+  font-size: 15px;
+}
+
+.message-content pre {
+  background: rgba(15, 23, 42, 0.9);
+  padding: 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  overflow: auto;
+}
+
+.message-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.message-action-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--text-tertiary);
+  font-size: 12px;
+  transition: all var(--transition);
+}
+
+.message-action-button:hover {
+  color: var(--text-primary);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.message-status {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.message-status.error {
+  color: var(--danger);
+}
+
+.tool-call {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(56, 189, 248, 0.32);
+  background: rgba(15, 23, 42, 0.75);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.tool-call .tool-name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--accent);
+}
+
+.tool-call pre {
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  padding: 12px;
+  margin: 0;
+  font-size: 13px;
+}
+
+.composer-shell {
+  position: sticky;
+  bottom: 0;
+  z-index: 3;
+  padding: 20px 28px 28px;
+  background: linear-gradient(0deg, rgba(2, 6, 23, 0.95) 0%, rgba(2, 6, 23, 0.75) 55%, transparent 100%);
+}
+
+.composer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 18px 38px rgba(2, 6, 23, 0.65);
+}
+
+.composer textarea {
+  width: 100%;
+  min-height: 80px;
+  max-height: 220px;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  line-height: 1.7;
+  transition:
+    border-color var(--transition),
+    box-shadow var(--transition);
+}
+
+.composer textarea:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.25);
+}
+
+.composer-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.composer-left,
+.composer-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.icon-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text-secondary);
+  transition: all var(--transition);
+}
+
+.icon-button:hover {
+  color: var(--text-primary);
+  border-color: rgba(56, 189, 248, 0.38);
+}
+
+.send-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 999px;
+  padding: 9px 18px;
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.24), rgba(14, 165, 233, 0.36));
+  color: var(--text-primary);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  font-weight: 600;
+  transition:
+    transform var(--transition),
+    box-shadow var(--transition),
+    opacity var(--transition);
+}
+
+.send-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.send-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px rgba(56, 189, 248, 0.28);
+}
+
+.attachment-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.attachment-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 12px;
+  padding: 6px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.65);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.attachment-pill button {
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text-primary);
+}
+
+.hint-text {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.empty-state {
+  margin: auto;
+  text-align: center;
+  max-width: 420px;
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(148, 163, 184, 0.26);
+  background: rgba(15, 23, 42, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: var(--text-secondary);
+}
+
+.alert {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  font-size: 13px;
+}
+
+.alert.warning {
+  background: rgba(251, 191, 36, 0.12);
+  border: 1px solid rgba(251, 191, 36, 0.32);
+  color: #facc15;
+}
+
+.alert.error {
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.32);
+  color: var(--danger);
+}
+
+.tooltip {
+  position: absolute;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: var(--bg-tooltip);
+  color: var(--text-primary);
+  font-size: 12px;
+  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.55);
+  transform: translate(-50%, -8px);
+  pointer-events: none;
+  opacity: 0;
+  transition:
+    opacity var(--transition),
+    transform var(--transition);
+}
+
+.tooltip.visible {
+  opacity: 1;
+  transform: translate(-50%, -12px);
+}
+
+.sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.65);
+  backdrop-filter: blur(4px);
+  z-index: 4;
+  display: none;
+}
+
+@media (max-width: 1180px) {
+  :root {
+    --sidebar-width: 260px;
+  }
+
+  .chat-header {
+    padding: 18px 20px 16px;
+  }
+
+  .message-timeline {
+    padding: 0 18px;
+  }
+
+  .composer-shell {
+    padding: 18px;
+  }
+}
+
+@media (max-width: 960px) {
+  .workspace,
+  .workspace.sidebar-collapsed {
+    grid-template-columns: var(--sidebar-width-collapsed) minmax(0, 1fr);
+  }
+
+  .sidebar {
+    padding: 20px 12px;
+  }
+
+  .sidebar.collapsed .brand-label,
+  .sidebar.collapsed .sidebar-content {
+    display: none;
+  }
+
+  .sidebar.collapsed .new-conversation-button {
+    padding: 12px;
+  }
+
+  .sidebar.collapsed .new-conversation-button span.label {
+    display: none;
+  }
+
+  .workspace.sidebar-collapsed .sidebar {
+    padding-inline: 12px;
+  }
+
+  .chat-header-top {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .chat-header-actions {
+    width: 100%;
+  }
+
+  .chat-header-actions button {
+    flex: 1;
+  }
+}
+
+@media (max-width: 720px) {
+  .workspace,
+  .workspace.sidebar-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sidebar {
+    position: absolute;
+    z-index: 5;
+    height: 100%;
+    width: min(320px, 100%);
+    transform: translateX(-100%);
+    transition: transform var(--transition);
+  }
+
+  .sidebar.is-open {
+    transform: translateX(0);
+    box-shadow: 0 28px 60px rgba(2, 6, 23, 0.75);
+  }
+
+  .sidebar-overlay {
+    display: block;
+  }
+
+  .chat-header {
+    padding-top: 16px;
+  }
+
+  .chat-header-top {
+    gap: 12px;
+  }
+
+  .composer {
+    padding: 14px;
+  }
+}

--- a/packages/codex-chat-app/src/types.ts
+++ b/packages/codex-chat-app/src/types.ts
@@ -1,0 +1,89 @@
+export type ChatRole = 'system' | 'user' | 'assistant' | 'tool';
+
+export type Attachment = {
+  id: string;
+  name: string;
+  size: number;
+  type: string;
+};
+
+export type ToolCall = {
+  id: string;
+  type: 'code_interpreter' | 'file_search' | 'web_browsing' | 'custom';
+  input: string;
+  output?: string;
+  createdAt: string;
+};
+
+export type MessageStatus = 'pending' | 'streaming' | 'completed' | 'error';
+
+export type ChatMessage = {
+  id: string;
+  role: ChatRole;
+  content: string;
+  createdAt: string;
+  status?: MessageStatus;
+  attachments?: Attachment[];
+  toolCalls?: ToolCall[];
+};
+
+export type ConversationSettings = {
+  model: string;
+  temperature: number;
+  maxOutputTokens?: number | null;
+};
+
+export type ToolConfig = {
+  codeInterpreter: boolean;
+  fileSearch: boolean;
+  webBrowsing: boolean;
+};
+
+export type Conversation = {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: ChatMessage[];
+  settings: ConversationSettings;
+  tools: ToolConfig;
+};
+
+export type ChatStateSnapshot = {
+  conversations: Conversation[];
+  activeConversationId: string | null;
+};
+
+export type ComposerAttachment = {
+  id: string;
+  file: File;
+};
+
+export type ChatRequest = {
+  conversationId: string;
+  settings: ConversationSettings;
+  tools: ToolConfig;
+  messages: ChatMessage[];
+  attachments?: Attachment[];
+  stream?: boolean;
+};
+
+export type ChatResponse = {
+  message: {
+    content: string;
+    toolCalls?: ToolCall[];
+    status?: MessageStatus;
+  };
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+  latencyMs?: number;
+  cached?: boolean;
+};
+
+export type DraftState = {
+  input: string;
+  attachments: ComposerAttachment[];
+};

--- a/packages/codex-chat-app/src/utils/markdown.ts
+++ b/packages/codex-chat-app/src/utils/markdown.ts
@@ -1,0 +1,80 @@
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const escapeAttribute = (value: string) => escapeHtml(value).replace(/`/g, '&#96;');
+
+type MarkdownSegment = { type: 'text'; content: string } | { type: 'code'; content: string; language?: string };
+
+const CODE_BLOCK_REGEX = /```([\w-]+)?\n?([\s\S]*?)```/g;
+
+const splitSegments = (content: string): MarkdownSegment[] => {
+  const segments: MarkdownSegment[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CODE_BLOCK_REGEX.exec(content)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', content: content.slice(lastIndex, match.index) });
+    }
+    segments.push({ type: 'code', language: match[1], content: match[2] ?? '' });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < content.length) {
+    segments.push({ type: 'text', content: content.slice(lastIndex) });
+  }
+  return segments;
+};
+
+const renderList = (lines: string[]): string => {
+  const isOrdered = lines.every((line) => /^\s*\d+\.\s+/.test(line));
+  const tag = isOrdered ? 'ol' : 'ul';
+  const items = lines.map((line) => {
+    const normalized = line.replace(/^\s*(?:[-*+]\s+|\d+\.\s+)/, '');
+    return `<li>${renderInline(normalized)}</li>`;
+  });
+  return `<${tag}>${items.join('')}</${tag}>`;
+};
+
+const renderInline = (raw: string): string => {
+  const escaped = escapeHtml(raw.trim());
+  if (!escaped) {
+    return '';
+  }
+  let transformed = escaped;
+  transformed = transformed.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  transformed = transformed.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+  transformed = transformed.replace(/`([^`]+)`/g, '<code>$1</code>');
+  transformed = transformed.replace(
+    /\[([^\]]+)\]\((https?:[^)\s]+)\)/g,
+    (_match, label: string, link: string) =>
+      `<a href="${escapeAttribute(link)}" target="_blank" rel="noreferrer noopener">${label}</a>`,
+  );
+  const lines = transformed.split(/\n+/);
+  if (lines.length === 1) {
+    return `<p>${lines[0]}</p>`;
+  }
+
+  const isList = lines.every((line) => /^\s*(?:[-*+]\s+|\d+\.\s+)/.test(line));
+  if (isList) {
+    return renderList(lines);
+  }
+
+  return lines.map((line) => `<p>${line}</p>`).join('');
+};
+
+export const renderMarkdownToHtml = (content: string): string => {
+  const segments = splitSegments(content);
+  return segments
+    .map((segment) => {
+      if (segment.type === 'code') {
+        const langAttr = segment.language ? ` data-lang="${escapeAttribute(segment.language)}"` : '';
+        return `<pre><code${langAttr}>${escapeHtml(segment.content.trim())}</code></pre>`;
+      }
+      return renderInline(segment.content);
+    })
+    .join('');
+};

--- a/packages/codex-chat-app/src/utils/storage.ts
+++ b/packages/codex-chat-app/src/utils/storage.ts
@@ -1,0 +1,50 @@
+import type { ChatStateSnapshot } from '../types';
+
+const STORAGE_KEY = 'codex-chat-state@v1';
+
+export const loadSnapshot = (): ChatStateSnapshot | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as ChatStateSnapshot;
+    if (!parsed.conversations) {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('[codex-chat-app] Failed to load snapshot', error);
+    return null;
+  }
+};
+
+export const persistSnapshot = (snapshot: ChatStateSnapshot) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+  } catch (error) {
+    console.warn('[codex-chat-app] Failed to persist snapshot', error);
+  }
+};
+
+export const clearSnapshot = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.removeItem(STORAGE_KEY);
+};
+
+export const createId = (prefix: string) => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return `${prefix}_${crypto.randomUUID()}`;
+  }
+  return `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+};

--- a/packages/codex-chat-app/tsconfig.json
+++ b/packages/codex-chat-app/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "types": ["vite/client"],
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/codex-chat-app/vite.config.ts
+++ b/packages/codex-chat-app/vite.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import htmlPlugin from 'vite-plugin-index-html';
+import { resolve } from 'path';
+
+export default defineConfig(({ mode }) => {
+  const isProd = mode === 'production';
+
+  return {
+    plugins: [
+      react(),
+      htmlPlugin({
+        input: './src/main.tsx',
+        preserveEntrySignatures: 'exports-only',
+      }),
+    ],
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, 'src'),
+      },
+    },
+    server: {
+      port: 5180,
+      cors: true,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+        'Access-Control-Allow-Headers': 'X-Requested-With, content-type, Authorization',
+      },
+      allowedHosts: ['.gitpod.io'],
+    },
+    css: {
+      devSourcemap: !isProd,
+    },
+    base: isProd ? '/codex-chat-app/' : '/',
+    build: {
+      sourcemap: !isProd,
+      outDir: 'dist',
+      rollupOptions: {
+        output: {
+          entryFileNames: 'entry.js',
+          chunkFileNames: 'chunks/[name]-[hash].js',
+          assetFileNames: 'assets/[name]-[hash][extname]',
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              return 'vendor';
+            }
+          },
+        },
+      },
+    },
+  };
+});

--- a/packages/config-center/public/micro-apps.json
+++ b/packages/config-center/public/micro-apps.json
@@ -32,6 +32,16 @@
       "enabled": true
     },
     {
+      "name": "codex-chat-app",
+      "displayName": "Codex 模型对话",
+      "devEntry": "http://localhost:5180",
+      "prodEntry": "https://zxkws.nyc.mn/codex-chat-app/",
+      "entry": "/codex-chat-app/",
+      "activeRule": ["/app/codex-chat"],
+      "sandbox": true,
+      "enabled": true
+    },
+    {
       "name": "vue-learning-app",
       "displayName": "Vue 学习微应用",
       "devEntry": "http://localhost:5178",

--- a/packages/main-app/src/layouts/BasicLayout/menuConfig.ts
+++ b/packages/main-app/src/layouts/BasicLayout/menuConfig.ts
@@ -15,6 +15,7 @@ const asideMenuConfig: MenuItem[] = [
     ],
   },
   { name: 'PDF 编辑器', path: '/app/pdf-editor' },
+  { name: '模型对话', path: '/app/codex-chat' },
   { name: '文本对比', path: '/textdiff' },
   { name: 'Curl Converter', path: '/curlconverter' },
   { name: '配置中心', path: '/app/config-hub' },


### PR DESCRIPTION
## Summary
- add a codex-chat micro application that delivers a ChatGPT Codex style workspace with conversation management, message composer, tool toggles, and local persistence
- document the required backend API contract and deployment notes for the new app
- register the micro app with the config center and main navigation menu

## Testing
- pnpm --filter codex-chat-app build
- pnpm --filter codex-chat-app typecheck

------
https://chatgpt.com/codex/tasks/task_b_690316c0125c832d95a02721eb7bca01